### PR TITLE
add replicaCount

### DIFF
--- a/charts/kube-ingress/nginx-ingress.yaml
+++ b/charts/kube-ingress/nginx-ingress.yaml
@@ -33,3 +33,10 @@ controller:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
+  resources: {}
+  # limits:
+  #   cpu: 10m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 512Mi

--- a/helm.sh
+++ b/helm.sh
@@ -341,6 +341,11 @@ helm_install() {
     if [ "${NAME}" == "nginx-ingress" ]; then
         get_base_domain
 
+        get_replicas ${NAMESPACE} nginx-ingress-controller
+        if [ "${REPLICAS}" != "" ]; then
+            EXTRA_VALUES="${EXTRA_VALUES} --set controller.replicaCount=${REPLICAS}"
+        fi
+
         get_cluster_ip ${NAMESPACE} nginx-ingress-controller
         if [ "${CLUSTER_IP}" != "" ]; then
             EXTRA_VALUES="${EXTRA_VALUES} --set controller.service.clusterIP=${CLUSTER_IP}"
@@ -758,6 +763,10 @@ create_cluster_role_binding() {
         SECRET=$(kubectl get secret -n ${_NAMESPACE} | grep ${_ACCOUNT}-token | awk '{print $1}')
         kubectl describe secret ${SECRET} -n ${_NAMESPACE} | grep 'token:'
     fi
+}
+
+get_replicas() {
+    REPLICAS=$(kubectl get deployment -n ${1} -o json | jq -r ".items[] | select(.metadata.name == \"${2}\") | .spec.replicas")
 }
 
 get_cluster_ip() {

--- a/tools.sh
+++ b/tools.sh
@@ -268,8 +268,7 @@ echo "${VERSION}"
 echo "================================================================================"
 _result "install guard..."
 
-# VERSION=$(curl -s https://api.github.com/repos/appscode/guard/releases/latest | jq -r '.tag_name')
-VERSION=0.1.2
+VERSION=$(curl -s https://api.github.com/repos/appscode/guard/releases/latest | jq -r '.tag_name')
 
 if [ "${GUARD}" != "${VERSION}" ]; then
     _result " ${GUARD} >> ${VERSION}"


### PR DESCRIPTION
helm upgrade 시 deployment 에서 .spec.replicas 를 찾아 replicaCount 에 넘겨줍니다.
기존에 배포 되었던 pod 수와 일치 시키기 위함 입니다.