### PR TITLE
add kube-state-metrics

### DIFF
--- a/charts/kube-system/kube-state-metrics.yaml
+++ b/charts/kube-system/kube-state-metrics.yaml
@@ -1,0 +1,4 @@
+# chart-repo: stable/kube-state-metrics
+# chart-version: 0.16.0
+
+nameOverride: kube-state-metrics

--- a/charts/monitor/datadog.yaml
+++ b/charts/monitor/datadog.yaml
@@ -15,4 +15,4 @@ datadog:
 #     enabled: true
 
 kubeStateMetrics:
-  enabled: false
+  enabled: KUBE_STATE_METRICS

--- a/charts/monitor/datadog.yaml
+++ b/charts/monitor/datadog.yaml
@@ -4,8 +4,15 @@
 nameOverride: datadog
 
 datadog:
+  clusterName: CLUSTER_NAME
   apiKey: API_KEY
   appKey: APP_KEY
 
-clusterAgent:
-  enabled: true
+# clusterAgent:
+#   enabled: true
+#   token: ""
+#   metricsProvider:
+#     enabled: true
+
+kubeStateMetrics:
+  enabled: false

--- a/charts/monitor/newrelic-infrastructure.yaml
+++ b/charts/monitor/newrelic-infrastructure.yaml
@@ -3,6 +3,6 @@
 
 nameOverride: newrelic-infrastructure
 
-licenseKey: LICENSE_KEY
-
 cluster: CLUSTER_NAME
+
+licenseKey: LICENSE_KEY

--- a/charts/monitor/prometheus.yaml
+++ b/charts/monitor/prometheus.yaml
@@ -42,6 +42,11 @@ alertmanager:
     #:EFS:storageClass: "efs"
     existingClaim: prometheus-alertmanager
 
+kubeStateMetrics:
+  ## If false, kube-state-metrics will not be installed
+  ##
+  enabled: KUBE_STATE_METRICS
+
 
 serverFiles:
   ## Alerts configuration

--- a/helm.sh
+++ b/helm.sh
@@ -460,6 +460,14 @@ helm_install() {
         replace_password ${CHART} "API_KEY" "****"
         # app key
         replace_password ${CHART} "APP_KEY" "****"
+
+        # kube-state-metrics
+        COUNT=$(kubectl get pods -n kube-system | grep kube-state-metrics | wc -l | xargs)
+        if [ "x${COUNT}" == "x0" ]; then
+            _replace "s/KUBE_STATE_METRICS/true/g" ${CHART}
+        else
+            _replace "s/KUBE_STATE_METRICS/false/g" ${CHART}
+        fi
     fi
 
     # for newrelic-infrastructure

--- a/helm.sh
+++ b/helm.sh
@@ -420,6 +420,14 @@ helm_install() {
     # for prometheus
     if [ "${NAME}" == "prometheus" ]; then
         replace_chart ${CHART} "SLACK_TOKEN"
+
+        # kube-state-metrics
+        COUNT=$(kubectl get pods -n kube-system | grep kube-state-metrics | wc -l | xargs)
+        if [ "x${COUNT}" == "x0" ]; then
+            _replace "s/KUBE_STATE_METRICS/true/g" ${CHART}
+        else
+            _replace "s/KUBE_STATE_METRICS/false/g" ${CHART}
+        fi
     fi
 
     # for grafana


### PR DESCRIPTION
* kube-state-metrics 를 추가 했습니다. (kube-system)
* prometheus 에서 kube-state-metrics 를 분리 했습니다.
* datadog 에서 kube-state-metrics 를 분리 했습니다.

서로 설치 하면 prometheus 에서 지표가 두배로 보이게 됩니다.
kube-state-metrics 가 먼저 설치 되어있으면 각 수집기는 설치 하지 않도록 옵션화 했습니다.
