### PR TITLE
efs-pvc-exporter chart yaml 구성 변경 및 helm.sh 수정

### DIFF
--- a/charts/batch/efs-pvc-exporter.yaml
+++ b/charts/batch/efs-pvc-exporter.yaml
@@ -5,16 +5,8 @@ image:
   repository: opsnowtools/efs-pvc-exporter
   tag: v0.1.7
 
-schedule: "0 7 * * 4"
+rolename: efs-viewer
 
-restart: OnFailure
+schedule: "SCHEDULE"
 
-serviceAccount: efs-pvc-exporter-sa
-namespace: batch
-roleRef: pvc-view
-
-configmap:
-  enabled: false
-
-secret:
-  enabled: false
+restart: RESTART

--- a/charts/batch/efs-pvc-exporter.yaml
+++ b/charts/batch/efs-pvc-exporter.yaml
@@ -5,7 +5,7 @@ image:
   repository: opsnowtools/efs-pvc-exporter
   tag: v0.1.7
 
-schedule: "0 16 * * 4"
+schedule: "0 7 * * 4"
 
 restart: OnFailure
 

--- a/custom/efs-pvc-exporter/templates/cron-job.yaml
+++ b/custom/efs-pvc-exporter/templates/cron-job.yaml
@@ -18,15 +18,3 @@ spec:
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-{{- with .Values.env }}
-            env:
-{{ toYaml . | indent 14 }}
-{{- end }}
-{{ if or .Values.configmap.enabled .Values.secret.enabled }}
-            envFrom:
-{{ end }}
-{{ if .Values.secret.enabled }}
-              - secretRef:
-                  name: {{ .Values.secret.name }}
-{{ end }}
-          restartPolicy: {{ .Values.restart }}

--- a/custom/efs-pvc-exporter/templates/cron-job.yaml
+++ b/custom/efs-pvc-exporter/templates/cron-job.yaml
@@ -14,7 +14,8 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: "{{ .Values.serviceAccount }}"
+          serviceAccountName: {{ include "fullname" . }}
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          restartPolicy: {{ .Values.restart }}

--- a/custom/efs-pvc-exporter/templates/rbac.yaml
+++ b/custom/efs-pvc-exporter/templates/rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ .Values.serviceAccount }}"
+  name: {{ include "fullname" . }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClnusterRole
 metadata:
-  name: "{{ .Values.roleRef }}"
+name: valve:{{ .Values.rolename }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "persistentvolumeclaims"]
@@ -20,12 +20,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "fullname" . }}
+name: valve:{{ .Values.rolename }}:{{ include "fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: "{{ .Values.serviceAccount }}"
-  namespace: "{{ .Values.namespace }}"
+  name: {{ include "fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: "{{ .Values.roleRef }}"
+  name: valve:{{ .Values.rolename }}
   apiGroup: rbac.authorization.k8s.io

--- a/custom/efs-pvc-exporter/templates/rbac.yaml
+++ b/custom/efs-pvc-exporter/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClnusterRole
+kind: ClusterRole
 metadata:
 name: valve:{{ .Values.rolename }}
 rules:

--- a/custom/efs-pvc-exporter/values.yaml
+++ b/custom/efs-pvc-exporter/values.yaml
@@ -1,18 +1,10 @@
 image:
   repository: opsnowtools/efs-pvc-exporter
   tag: v0.1.7
-schedule: "0 16 * * 4"
+schedule: "0 7 * * 4"
 
 restart: OnFailure
 
 serviceAccount: efs-pvc-exporter-sa
 namespace: batch
 roleRef: pvc-view
-
-env: {}
-
-configmap:
-  enabled: false
-
-secret:
-  enabled: false

--- a/custom/efs-pvc-exporter/values.yaml
+++ b/custom/efs-pvc-exporter/values.yaml
@@ -1,10 +1,5 @@
 image:
   repository: opsnowtools/efs-pvc-exporter
   tag: v0.1.7
-schedule: "0 7 * * 4"
 
-restart: OnFailure
-
-serviceAccount: efs-pvc-exporter-sa
-namespace: batch
-roleRef: pvc-view
+rolename: efs-viewer

--- a/helm.sh
+++ b/helm.sh
@@ -567,6 +567,16 @@ helm_install() {
         replace_chart ${CHART} "CONFIGMAP_NAME" "${NAME}"
     fi
 
+    # for efs-pvc-exporter
+    if [ "${NAME}" == "efs-pvc-exporter" ]; then
+        _replace "s/AWS_REGION/${REGION}/g" ${CHART}
+
+        replace_chart ${CHART} "SCHEDULE" "* * * * *"
+
+        replace_chart ${CHART} "RESTART" "OnFailure" # "Always", "OnFailure", "Never"
+    fi
+
+
     # for efs-mount
     if [ "${EFS_ID}" != "" ]; then
         _replace "s/#:EFS://g" ${CHART}

--- a/helm.sh
+++ b/helm.sh
@@ -558,8 +558,6 @@ helm_install() {
 
     # for elasticsearch-snapshot
     if [ "${NAME}" == "elasticsearch-snapshot" ]; then
-        _replace "s/AWS_REGION/${REGION}/g" ${CHART}
-
         replace_chart ${CHART} "SCHEDULE" "0 0 * * *"
 
         replace_chart ${CHART} "RESTART" "OnFailure" # "Always", "OnFailure", "Never"
@@ -569,13 +567,10 @@ helm_install() {
 
     # for efs-pvc-exporter
     if [ "${NAME}" == "efs-pvc-exporter" ]; then
-        _replace "s/AWS_REGION/${REGION}/g" ${CHART}
-
         replace_chart ${CHART} "SCHEDULE" "* * * * *"
 
         replace_chart ${CHART} "RESTART" "OnFailure" # "Always", "OnFailure", "Never"
     fi
-
 
     # for efs-mount
     if [ "${EFS_ID}" != "" ]; then


### PR DESCRIPTION
chart yaml 구성 변경
- static한 값들을 values.yaml로 이동(schedule / restart policy)
- 사용하지 않는 parameter 제거
- cluster role / cluster role binding 시 naming을 다음과 같이 변경
  - Cluster role ==> valve:[Values yaml에 정의된 rolename]
  - Cluster role binding ==> valve:[Values yaml에 정의된 rolename]:[Service Account name]

helm.sh 수정
- efs-pvc-exporter 차트가 있을 때 parameter를 받을 수 있도록 정의(schedule / restart policy)